### PR TITLE
Fix batch & receive dialog address generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ See the [Stage 2](/../../milestone/2) milestone
 - [ ] Contact/Payment Share Features
   - [ ] SMS (sms:)
   - [ ] Email (mailto:)
-- [ ] Transactions view
-  - [ ] Table with filter/sort
-  - [ ] Select & Copy as CSV
 - [ ] View & manage addresses associated with Wallet
 - [ ] Coin Control
   - [ ] Set Fund Denomination for Send & Request payments

--- a/src/components/contacts-list.js
+++ b/src/components/contacts-list.js
@@ -122,7 +122,7 @@ const initialState = {
     `
   },
   footer: async state => html`
-    <datalist id="contactAliases">
+    <datalist id="contactSendAliases">
       ${
         state.contacts.length > 0
           ? (
@@ -138,9 +138,27 @@ const initialState = {
                       contact.info?.name || contact.alias
                     }</option>`
                   })
-                // .map(
-                //   async c => await state.item(c)
-                // )
+              )
+            ).join('')
+          : ''
+      }
+    </datalist>
+    <datalist id="contactReceiveAliases">
+      ${
+        state.contacts.length > 0
+          ? (
+              await Promise.all(
+                state.contacts
+                  .filter(
+                    c => c.alias &&
+                    Object.keys(c.incoming || {}).length > 0
+                  ).map(contact => {
+                    return html`<option value="@${
+                      contact.alias
+                    }">${
+                      contact.info?.name || contact.alias
+                    }</option>`
+                  })
               )
             ).join('')
           : ''

--- a/src/components/contacts-list.js
+++ b/src/components/contacts-list.js
@@ -44,7 +44,11 @@ const initialState = {
     <div>
       ${
         state.contacts.length > 0
-          ? (await Promise.all(state.contacts.map(async c => await state.item(c)))).join('')
+          ? (
+            await Promise.all(
+              state.contacts.map(async c => await state.item(c))
+            )
+          ).join('')
           : ''
       }
       ${

--- a/src/components/main-footer.js
+++ b/src/components/main-footer.js
@@ -4,7 +4,7 @@ const initialState = {
   rendered: null,
   content: state => html`
     <footer>
-      <h4>Alpha stage, not production ready. <span>Use at your own risk.</span></h4>
+      <h4>Alpha stage, not production ready. <div>Use at your own risk.</div></h4>
       <h5>Checkout the <a target="_blank" href="https://github.com/dashhive/wallet-ui">Source Code</a></h5>
     </footer>
   `,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -134,3 +134,11 @@ export const DASH_URI_REGEX = new RegExp(
   /^(?:web\+)?(?<protocol>dash)(?:[:])(?:\/\/)?(?<address>X[a-zA-Z0-9]{33})?(?:(?:[?])(?<params>.+))?/,
   'ig'
 )
+
+export const RECEIVE = 0 // DashHd.RECEIVE
+export const CHANGE = 1 // DashHd.CHANGE
+
+export const USAGE = {
+  RECEIVE,
+  CHANGE,
+}

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1008,10 +1008,11 @@ export function getPartialHDPath(wallet) {
   ].join('/')
 }
 
-export function getAddressIndexFromUsage(wallet, account) {
+export function getAddressIndexFromUsage(wallet, account, usage) {
+  let usageIndex = usage ?? wallet.usageIndex
   return {
     ...account,
-    usageIndex: wallet.usageIndex,
-    addressIndex: account.usage[wallet.usageIndex],
+    usageIndex,
+    addressIndex: account.usage[usageIndex],
   }
 }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -385,6 +385,52 @@ export function envoy(obj, ...initListeners) {
   })
 }
 
+/**
+ * Creates a reactive signal
+ *
+ * Inspired By
+ * {@link https://gist.github.com/developit/a0430c500f5559b715c2dddf9c40948d Valoo} &
+ * {@link https://dev.to/ratiu5/implementing-signals-from-scratch-3e4c Signals from Scratch}
+ *
+ * @example
+ *    let count = createSignal(0)
+ *    console.log(count.value) // 0
+ *    count.value = 2
+ *    console.log(count.value) // 2
+ *
+ *    let off = count.on((value) => {
+ *      document.querySelector("body").innerHTML = value;
+ *    });
+ *
+ *    off(); // unsubscribe
+ *
+ * @param {Object} initialValue inital value
+*/
+export function createSignal(initialValue) {
+  let _value = initialValue;
+  let _last = _value;
+  const subs = [];
+
+  function pub() {
+    for (let s of subs) {
+      s && s(_value, _last);
+    }
+  }
+
+  return {
+    get value() { return _value; },
+    set value(v) {
+      _last = _value
+      _value = v;
+      pub();
+    },
+    on: s => {
+      const i = subs.push(s)-1;
+      return () => { subs[i] = 0; };
+    }
+  }
+}
+
 export async function restate(
   state = {},
   renderState = {},

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -999,3 +999,19 @@ export async function getUniqueAlias(aliases, preferredAlias) {
 
   return uniqueAlias
 }
+
+export function getPartialHDPath(wallet) {
+  return [
+    wallet.accountIndex,
+    wallet.usageIndex,
+    wallet.addressIndex,
+  ].join('/')
+}
+
+export function getAddressIndexFromUsage(wallet, account) {
+  return {
+    ...account,
+    usageIndex: wallet.usageIndex,
+    addressIndex: account.usage[wallet.usageIndex],
+  }
+}

--- a/src/helpers/wallet.js
+++ b/src/helpers/wallet.js
@@ -514,6 +514,7 @@ export async function generateAddressIterator(
   walletId,
   accountIndex,
   addressIndex,
+  usageIndex = DashHd.RECEIVE,
 ) {
   // let xkeyId = await DashHd.toId(xkey);
   let key = await xkey.deriveAddress(addressIndex);
@@ -541,7 +542,7 @@ export async function generateAddressIterator(
           xkeyId,
           accountIndex,
           addressIndex,
-          usageIndex: xkey.index,
+          usageIndex,
         },
       )
     })
@@ -583,6 +584,7 @@ export async function batchAddressGenerate(
         wallet.id,
         accountIndex,
         addrIdx,
+        usageIndex,
       )
     )
   }
@@ -621,6 +623,7 @@ export async function batchAddressUsageGenerate(
         wallet.id,
         accountIndex,
         addrIdx,
+        DashHd.RECEIVE,
       )
     )
     addresses.push(
@@ -630,6 +633,7 @@ export async function batchAddressUsageGenerate(
         wallet.id,
         accountIndex,
         addrIdx,
+        DashHd.CHANGE,
       )
     )
   }

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,12 @@ figure h4 {
 .jc-end {
   justify-content: end;
 }
+.as-start {
+  align-self: start;
+}
+.as-end {
+  align-self: end;
+}
 .ji-left {
   justify-items: left;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,11 +7,13 @@ import {
   sortContactsByAlias,
   getStoreData,
   formDataEntries,
+  getAddressIndexFromUsage,
 } from './helpers/utils.js'
 
 import {
   DUFFS,
   OIDC_CLAIMS,
+  // USAGE,
 } from './helpers/constants.js'
 
 import {
@@ -180,7 +182,7 @@ let contactsList = await setupContactsList(
 
           let shareAccount = await deriveWalletData(
             appState.phrase,
-            contactAccountID
+            contactAccountID,
           )
 
           if (!contactData.outgoing) {
@@ -250,7 +252,7 @@ let contactsList = await setupContactsList(
 
             shareAccount = await deriveWalletData(
               appState.phrase,
-              accountIndex
+              accountIndex,
             )
 
             console.log('main.js contact account', shareAccount)
@@ -543,8 +545,8 @@ async function main() {
   })
 
   appDialogs.requestQr = await requestQrRig({
-    mainApp, setupDialog, appDialogs, appState, userInfo, store,
-    deriveWalletData, batchGenAcctAddrs,
+    mainApp, appDialogs, appState, appTools, userInfo, store,
+    setupDialog, deriveWalletData, batchGenAcctAddrs,
   })
 
   appDialogs.pairQr = await pairQrRig({
@@ -614,6 +616,19 @@ async function main() {
 
   if (appState.phrase && !wallet) {
     wallet = await deriveWalletData(appState.phrase)
+
+    let tmpAcct = await store.accounts.getItem(
+      wallet.xkeyId,
+    ) || {}
+    let tmpAcctWallet = getAddressIndexFromUsage(wallet, tmpAcct)
+
+    if (tmpAcctWallet?.addressIndex > 0) {
+      wallet = await deriveWalletData(
+        appState.phrase,
+        tmpAcctWallet?.accountIndex,
+        tmpAcctWallet?.addressIndex,
+      )
+    }
   }
 
   document.addEventListener('submit', async event => {

--- a/src/main.js
+++ b/src/main.js
@@ -665,6 +665,15 @@ async function main() {
           let tmpAcct = await store.accounts.getItem(
             wallet.xkeyId,
           ) || {}
+          let tmpAcctWallet = getAddressIndexFromUsage(wallet, tmpAcct)
+
+          if (tmpAcctWallet?.addressIndex > 0) {
+            wallet = await deriveWalletData(
+              appState.phrase,
+              tmpAcctWallet?.accountIndex,
+              tmpAcctWallet?.addressIndex,
+            )
+          }
 
           // tmpAcct.usage = tmpAcct?.usage || [0,0]
           // tmpAcct.usage[

--- a/src/main.js
+++ b/src/main.js
@@ -31,6 +31,7 @@ import {
   sendTx,
   getAddrsWithFunds,
   storedData,
+  getUnusedChangeAddress,
 } from './helpers/wallet.js'
 import {
   localForageBaseCfg,
@@ -529,7 +530,7 @@ async function main() {
     mainApp, appDialogs, appState, appTools, store,
     wallet, account: appState.account, walletFunds,
     setupDialog, deriveWalletData, createTx,
-    getAddrsWithFunds, batchGenAcctAddrs,
+    getAddrsWithFunds, batchGenAcctAddrs, getUnusedChangeAddress,
   })
 
   appDialogs.txInfo = await txInfoRig({
@@ -1075,7 +1076,7 @@ async function main() {
               storedAddr.xkeyId,
             ) || {}
 
-            let { addresses, finalAddressIndex } = await batchGenAcctAddrs(
+            let batchAddrs = await batchGenAcctAddrs(
               wallet,
               tmpWalletAcct,
               tmpWalletAcct.usage[storedAddr.usageIndex],
@@ -1086,8 +1087,7 @@ async function main() {
               {
                 // walletTemp,
                 tmpWalletAcct,
-                finalAddressIndex,
-                addresses,
+                batchAddrs,
               }
             )
           })

--- a/src/rigs/add-contact.js
+++ b/src/rigs/add-contact.js
@@ -486,12 +486,12 @@ export let addContactRig = (async function (globals) {
           // event.target.contactAlias.setCustomValidity('')
           // event.target.contactAlias.reportValidity()
 
-          console.log('ADD CONTACT!', state, event)
+          // console.log('ADD CONTACT!', state, event)
 
           let fde = formDataEntries(event)
           let parsedAddr
 
-          console.log('scanContact', appDialogs.scanContact)
+          // console.log('scanContact', appDialogs.scanContact)
 
           if (fde?.intent === 'scan_new_contact') {
             await appDialogs.scanContact.render(

--- a/src/rigs/edit-contact.js
+++ b/src/rigs/edit-contact.js
@@ -408,7 +408,7 @@ export let editContactRig = (async function (globals) {
           event.preventDefault()
           event.stopPropagation()
 
-          console.log('EDIT CONTACT!', state, event)
+          // console.log('EDIT CONTACT!', state, event)
 
           let fde = formDataEntries(event)
 

--- a/src/rigs/phrase-generate.js
+++ b/src/rigs/phrase-generate.js
@@ -99,7 +99,7 @@ export let phraseGenerateRig = (async function (globals) {
           localStorage.selectedAlias = appState.selectedAlias
 
           let usage = [0,0]
-          usage[wallet.usageIndex] = wallet.addressIndex
+          // usage[wallet.usageIndex] = wallet.addressIndex
 
           let newAccount = await store.accounts.setItem(
             wallet.xkeyId,

--- a/src/rigs/phrase-import.js
+++ b/src/rigs/phrase-import.js
@@ -418,7 +418,7 @@ export let phraseImportRig = (async function (globals) {
           localStorage.selectedWallet = appState.selectedWallet
 
           let usage = [0,0]
-          usage[wallet.usageIndex] = wallet.addressIndex
+          // usage[wallet.usageIndex] = wallet.addressIndex
 
           let newAccount = await store.accounts.setItem(
             wallet.xkeyId,

--- a/src/rigs/request-qr.js
+++ b/src/rigs/request-qr.js
@@ -196,6 +196,17 @@ export let requestQrRig = (async function (globals) {
             resolve('cancel')
           }
 
+          await requestQr.render(
+            {
+              wallet: state.wallet,
+              selectedWallet: state.wallet,
+              amount: state.amount,
+              contact: state.contact,
+              to: state.to,
+            },
+            'afterend',
+          )
+
           setTimeout(t => {
             state.modal.rendered[state.slugs.dialog] = null
             event?.target?.remove()

--- a/src/rigs/request-qr.js
+++ b/src/rigs/request-qr.js
@@ -320,7 +320,7 @@ export let requestQrRig = (async function (globals) {
 
             let contact, inWallet
 
-            if (state.to.startsWith('@')) {
+            if (state.to?.startsWith('@')) {
               contact = appState.contacts.find(
                 c => c.alias === state.to.substring(1)
               )

--- a/src/rigs/request-qr.js
+++ b/src/rigs/request-qr.js
@@ -7,13 +7,16 @@ import {
   generatePaymentRequestURI,
   fixedDash,
   roundUsing,
+  getPartialHDPath,
+  getAddressIndexFromUsage,
 } from '../helpers/utils.js'
 
 export let requestQrRig = (async function (globals) {
   'use strict';
 
   let {
-    mainApp, setupDialog, appDialogs, appState, userInfo,
+    mainApp, setupDialog, appDialogs, appState, userInfo, store,
+    deriveWalletData, batchGenAcctAddrs,
   } = globals;
 
   let requestQr = await setupDialog(
@@ -23,6 +26,8 @@ export let requestQrRig = (async function (globals) {
       address: '',
       submitTxt: html`<svg width="24" height="24" viewBox="0 0 24 24"><use xlink:href="#icon-arrow-circle-down"></use></svg> Receive Payment`,
       submitAlt: 'Receive Payment',
+      generateAddrTxt: 'Generate New Address',
+      generateAddrAlt: 'Generate new address',
       cancelTxt: 'Cancel',
       cancelAlt: `Cancel`,
       placement: 'wide',
@@ -32,21 +37,72 @@ export let requestQrRig = (async function (globals) {
       footer: state => html`<footer class="center">
         <sub>Share this QR code to receive funds</sub>
       </footer>`,
-      showAmount: state => {
-        if (!state.amount) {
-          return ''
+      // showAmount: state => {
+      //   if (!state.amount) {
+      //     return ''
+      //   }
+
+      //   return html`
+      //     <article>
+      //       <figure>
+      //         <figcaption>Amount</figcaption>
+      //         <div class="big">
+      //           <svg width="32" height="33" viewBox="0 0 32 33">
+      //             <use xlink:href="#icon-dash-mark"></use>
+      //           </svg>
+      //           ${state.amount}
+      //         </div>
+      //       </figure>
+      //     </article>
+      //   `
+      // },
+      getContact: state => {
+        let to = state.contact?.info?.name
+        if (!to && state.contact?.alias) {
+          to = `@${state.contact?.alias}`
+        }
+        if (!to) {
+          to = state.to || ''
+        }
+        return to
+      },
+      showFrom: state => {
+        let contact = state.getContact(state)
+
+        if (contact) {
+          return html`From <span>${contact}</span>`
         }
 
+        if (state.amount) {
+          return html`Amount`
+        }
+
+        return html``
+      },
+      showAmount: state => {
+        let output = html``
+
+        if (state.amount) {
+          output = html`
+            <div class="big">
+              <svg width="26" height="27" viewBox="0 0 32 33">
+                <use xlink:href="#icon-dash-mark"></use>
+              </svg>
+              ${state.amount}
+            </div>
+          `
+        }
+
+        return output
+      },
+      showContactAndAmount: state => {
         return html`
           <article>
             <figure>
-              <figcaption>Amount</figcaption>
-              <div class="big">
-                <svg width="32" height="33" viewBox="0 0 32 33">
-                  <use xlink:href="#icon-dash-mark"></use>
-                </svg>
-                ${state.amount}
-              </div>
+              <figcaption class="txt-small">
+                ${state.showFrom(state)}
+              </figcaption>
+              ${state.showAmount(state)}
             </figure>
           </article>
         `
@@ -66,22 +122,49 @@ export let requestQrRig = (async function (globals) {
           />
         `
       },
+      generateNextAddress: state => {
+        return html`
+          <div class="">
+            <button
+              class="pill rounded"
+              type="submit"
+              name="intent"
+              value="generate_address"
+              title="${state.generateAddrAlt}"
+            >
+              <span>
+                <i class="icon-plus-circle"></i>
+                <!-- <svg class="rotate-x-to-plus" width="24" height="24" viewBox="0 0 24 24">
+                  <use xlink:href="#icon-x"></use>
+                </svg> -->
+                <!-- <svg class="plus-circle" width="26" height="26" viewBox="0 0 16 16">
+                  <use xlink:href="#icon-plus-circle"></use>
+                </svg> -->
+                ${state.generateAddrTxt}
+              </span>
+            </button>
+          </div>
+        `
+      },
       content: state => html`
         ${state.header(state)}
 
         <fieldset class="share solo">
           <aside>
-            ${state.showAmount(state)}
-            <span class="qr" title="Open QR Code in new Window">${qrSvg(
-              generatePaymentRequestURI(state),
-              {
-                indent: 0,
-                padding: 4,
-                size: 'mini',
-                container: 'svg-viewbox',
-                join: true,
-              }
-            )}</span>
+            ${state.generateNextAddress(state)}
+            ${state.showContactAndAmount(state)}
+            <span class="qr" title="Open QR Code in new Window">
+              ${qrSvg(
+                generatePaymentRequestURI(state),
+                {
+                  indent: 0,
+                  padding: 4,
+                  size: 'mini',
+                  container: 'svg-viewbox',
+                  join: true,
+                }
+              )}
+            </span>
             <input readonly value="${generatePaymentRequestURI(state)}" />
             <button id="pair-copy" class="pill rounded copy" title="Copy URI (${generatePaymentRequestURI(state)})">
               <i class="icon-copy"></i>
@@ -153,17 +236,112 @@ export let requestQrRig = (async function (globals) {
 
           let fde = formDataEntries(event)
 
+          // getPartialHDPath,
+          // getAddressIndexFromUsage,
+
+          let tmpAcct = await store.accounts.getItem(
+            state.wallet.xkeyId,
+          ) || {}
+          let tmpAcctWallet = getAddressIndexFromUsage(state.wallet, tmpAcct)
+
+          let storedPath = getPartialHDPath(tmpAcctWallet)
+          let oldPath = getPartialHDPath(state.wallet)
+
+          let nextAddrIndex = (tmpAcctWallet?.addressIndex ?? -1)
+
+          if (nextAddrIndex < state.wallet.addressIndex) {
+            nextAddrIndex = state.wallet.addressIndex
+          }
+
+          if (fde?.intent === 'generate_address') {
+            nextAddrIndex = nextAddrIndex + 1
+          }
+
+          state.wallet = await deriveWalletData(
+            appState.phrase,
+            tmpAcctWallet.accountIndex,
+            nextAddrIndex,
+            tmpAcctWallet.usageIndex,
+          )
+          state.selectedWallet = state.wallet
+
+          // tmpAcct.usage = tmpAcct?.usage// || [0,0]
+          tmpAcct.usage[
+            state.wallet.usageIndex
+          ] = state.wallet.addressIndex
+
+          let newPath = getPartialHDPath(state.wallet)
+
+          if (fde?.intent === 'generate_address') {
+            tmpAcct = await store.accounts.setItem(
+              state.wallet.xkeyId,
+              {
+                ...tmpAcct,
+                updatedAt: (new Date()).toISOString(),
+                address: state.wallet.address,
+              }
+            )
+
+            batchGenAcctAddrs(
+              state.wallet,
+              tmpAcct,
+              state.wallet.usageIndex,
+            )
+              .then(a => {
+                console.log(
+                  `${fde.intent} BATCH GEN ADDRS`,
+                  a
+                )
+              })
+
+            console.log(
+              'GENERATE NEW ADDRESS',
+              {state, event, fde, tmpAcct},
+              [
+                storedPath,
+                oldPath,
+                newPath,
+              ],
+            )
+
+            await requestQr.render(
+              {
+                wallet: state.wallet,
+                selectedWallet: state.wallet,
+                amount: state.amount,
+                contact: state.contact,
+                to: state.to,
+              },
+              'afterend',
+            )
+
+            return;
+          }
           if (fde?.intent === 'select_address') {
             // console.log('SELECT AN ADDRESS', {state, event, fde})
+
+            console.log(
+              'SELECT AN ADDRESS',
+              {state, event, fde, tmpAcct},
+              [
+                storedPath,
+                oldPath,
+                newPath,
+              ]
+            )
 
             await appDialogs.sendOrReceive.render({
               action: 'receive',
               amount: state.amount || 0,
-              wallet: state.wallet,
+              // wallet: state.wallet,
+              wallet: state.selectedWallet || state.wallet,
+              // selectedWallet: state.wallet,
               account: appState.account,
               contacts: appState.contacts,
               userInfo,
-              to: null,
+              to: state.to || null,
+              contact: state.contact,
+              // to: state.contact?.alias ? `@${state.contact?.alias}` : null,
             })
             appDialogs.sendOrReceive.showModal()
 

--- a/src/rigs/send-confirm.js
+++ b/src/rigs/send-confirm.js
@@ -57,7 +57,7 @@ export let sendConfirmRig = (async function (globals) {
           to = `@${state.contact?.alias}`
         }
         if (!to) {
-          to = state.to
+          to = state.to || ''
         }
         return to
       },

--- a/src/rigs/send-or-request.js
+++ b/src/rigs/send-or-request.js
@@ -463,48 +463,39 @@ export let sendOrReceiveRig = (async function (globals) {
               tmpAcctWallet.usageIndex,
             )
           } else {
-            // inWallet.addressIndex = inWallet.addressIndex + 1
-            receiveWallet = await deriveWalletData(
-              appState.phrase,
-              inWallet.accountIndex,
-              inWallet.addressIndex,
+            let tmpAcct = await store.accounts.getItem(
+              inWallet.xkeyId,
+            ) || {}
+            let tmpAcctWallet = getAddressIndexFromUsage(
+              {},
+              tmpAcct,
+              USAGE.RECEIVE,
             )
 
-            // await appTools.storedData.encryptItem(
-            //   store.contacts,
-            //   inWallet.xkeyId,
-            //   {
-            //     ...contact,
-            //     updatedAt: (new Date()).toISOString(),
-            //     incoming: {
-            //       ...contact.incoming,
-            //       [`${inWallet.walletId}/${inWallet.xkeyId}`]: {
-            //         ...inWallet,
-            //         address: receiveWallet.address,
-            //         addressIndex: receiveWallet.addressIndex,
-            //       }
-            //     },
-            //   },
-            //   false,
-            // )
+            receiveWallet = await deriveWalletData(
+              appState.phrase,
+              tmpAcctWallet.accountIndex,
+              tmpAcctWallet.addressIndex,
+            )
 
-            // let tmpAcct = await store.accounts.getItem(
-            //   receiveWallet.xkeyId,
-            // ) || {}
-            // let changeWallet = {
-            //   ...receiveWallet,
-            //   usageIndex: USAGE.CHANGE,
-            // }
-            // let tmpAcctWallet = getAddressIndexFromUsage(
-            //   changeWallet,
-            //   tmpAcct,
-            // )
-            // let derivedChangeWallet = await deriveWalletData(
-            //   appState.phrase,
-            //   tmpAcctWallet.accountIndex,
-            //   tmpAcctWallet.addressIndex,
-            //   tmpAcctWallet.usageIndex,
-            // )
+            await appTools.storedData.encryptItem(
+              store.contacts,
+              inWallet.xkeyId,
+              {
+                ...contact,
+                updatedAt: (new Date()).toISOString(),
+                incoming: {
+                  ...contact.incoming,
+                  [`${inWallet.walletId}/${inWallet.xkeyId}`]: {
+                    ...inWallet,
+                    ...tmpAcct,
+                    address: receiveWallet.address,
+                  }
+                },
+              },
+              false,
+            )
+
             // console.log(
             //   'derive change wallet',
             //   {

--- a/src/rigs/send-or-request.js
+++ b/src/rigs/send-or-request.js
@@ -17,7 +17,7 @@ export let sendOrReceiveRig = (async function (globals) {
   let {
     mainApp, setupDialog, appDialogs, appState, appTools, store,
     createTx, deriveWalletData, getAddrsWithFunds, batchGenAcctAddrs,
-    wallet, wallets, accounts, walletFunds,
+    wallet, wallets, accounts, walletFunds, getUnusedChangeAddress,
   } = globals
 
   let sendOrReceive = await setupDialog(
@@ -582,21 +582,14 @@ export let sendOrReceiveRig = (async function (globals) {
               let tmpAcct = await store.accounts.getItem(
                 state.wallet.xkeyId,
               ) || {}
-              let changeWallet = {
-                ...state.wallet,
-                usageIndex: USAGE.CHANGE,
-              }
               let tmpAcctWallet = getAddressIndexFromUsage(
-                changeWallet,
+                state.wallet,
                 tmpAcct,
+                USAGE.CHANGE,
               )
-              let derivedChangeWallet = await deriveWalletData(
-                appState.phrase,
-                tmpAcctWallet.accountIndex,
-                tmpAcctWallet.addressIndex,
-                tmpAcctWallet.usageIndex,
-              )
-              changeAddress = derivedChangeWallet.address
+
+              changeAddress = await getUnusedChangeAddress(tmpAcctWallet)
+
               console.log(
                 'derive change wallet',
                 {
@@ -605,8 +598,7 @@ export let sendOrReceiveRig = (async function (globals) {
                   tmpAcct,
                   tmpAcctWallet,
                   stateWallet: state.wallet,
-                  changeWallet,
-                  derivedChangeWallet,
+                  // derivedChangeWallet,
                 }
               )
 

--- a/src/rigs/wallet-decrypt.js
+++ b/src/rigs/wallet-decrypt.js
@@ -169,7 +169,7 @@ export let walletDecryptRig = (async function (globals) {
               wallets = initialized.wallets
 
               let usage = [0,0]
-              usage[wallet.usageIndex] = wallet.addressIndex
+              // usage[wallet.usageIndex] = wallet.addressIndex
 
               let newAccount = await store.accounts.setItem(
                 wallet.xkeyId,

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -79,6 +79,7 @@ form fieldset div.input {
   display: flex;
   flex-direction: row;
   align-items: center;
+  width: 100%;
 }
 form fieldset div:has(input),
 form fieldset div:has(input + button),

--- a/src/styles/icons.css
+++ b/src/styles/icons.css
@@ -74,3 +74,7 @@
   line-height: 1;
   vertical-align: middle;
 }
+
+.rotate-x-to-plus {
+  transform: rotateZ(45deg);
+}


### PR DESCRIPTION
Related to #53 and issues surrounding it, we've updated the Receive dialog to have a button that manually generates a new address as well as trigger the batch address generation if the indexed db cache is low.

We've also updated the Send dialog to support change addresses rather than re-using receive addresses.